### PR TITLE
Add UI/UX designer portfolio website

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dhivya Sundaram - UI/UX Designer</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1 class="logo">Dhivya Sundaram</h1>
+    <nav>
+      <ul class="nav-links">
+        <li><a href="#about">About</a></li>
+        <li><a href="#work">Work</a></li>
+        <li><a href="#contact">Contact</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <section id="hero" class="hero">
+    <h2>Designing intuitive &amp; engaging experiences</h2>
+    <p>UI/UX designer passionate about crafting clean user-centered interfaces.</p>
+  </section>
+
+  <section id="about" class="about">
+    <h2>About Me</h2>
+    <p>
+      I'm a user interface and experience designer focused on solving problems
+      through empathy and research. I enjoy turning complex challenges into
+      elegant solutions.
+    </p>
+  </section>
+
+  <section id="work" class="work">
+    <h2>Selected Work</h2>
+    <div class="project">
+      <h3>Project One</h3>
+      <p>A responsive web app for planning collaborative design sprints.</p>
+    </div>
+    <div class="project">
+      <h3>Project Two</h3>
+      <p>Mobile prototype for a personal finance tool with real-time feedback.</p>
+    </div>
+    <div class="project">
+      <h3>Project Three</h3>
+      <p>Redesign of an e-commerce checkout to reduce friction and increase conversions.</p>
+    </div>
+  </section>
+
+  <section id="contact" class="contact">
+    <h2>Contact</h2>
+    <p>Have a project or idea? <a href="mailto:designer@example.com">Let's talk</a>.</p>
+  </section>
+
+  <footer class="footer">
+    <p>&copy; 2024 Dhivya Sundaram. All rights reserved.</p>
+  </footer>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,70 @@
+/* Basic reset */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: Arial, Helvetica, sans-serif;
+  line-height: 1.6;
+  color: #333;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background: #fff;
+  border-bottom: 1px solid #eaeaea;
+  position: sticky;
+  top: 0;
+}
+
+.logo {
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 1.5rem;
+}
+
+.nav-links a {
+  text-decoration: none;
+  color: #333;
+}
+
+.hero {
+  padding: 4rem 2rem;
+  text-align: center;
+  background: #f5f5f5;
+}
+
+section {
+  padding: 4rem 2rem;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.project {
+  margin-bottom: 2rem;
+}
+
+.project h3 {
+  margin-bottom: 0.5rem;
+}
+
+.contact a {
+  color: #0077cc;
+  text-decoration: none;
+}
+
+.footer {
+  text-align: center;
+  padding: 2rem;
+  background: #f5f5f5;
+}


### PR DESCRIPTION
## Summary
- add root-level portfolio site for UI/UX designer with hero, about, work and contact sections
- style layout with sticky header, navigation links and responsive spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e32f2784c8327a5bfe2fa5880868c